### PR TITLE
Allow #present to accept string as presenter name

### DIFF
--- a/lib/keynote.rb
+++ b/lib/keynote.rb
@@ -47,7 +47,7 @@ module Keynote
     #   @return [Keynote::Presenter]
     #
     def present(view, *objects)
-      if objects[0].is_a?(Symbol)
+      if objects[0].is_a?(Symbol) || objects[0].is_a?(String)
         name = objects.shift
       else
         name = presenter_name_from_object(objects[0])

--- a/spec/keynote_spec.rb
+++ b/spec/keynote_spec.rb
@@ -65,7 +65,7 @@ describe Keynote do
     end
 
     it "should find and instantiate explicitly" do
-      p = Keynote.present(view, :"keynote/nested", 'hello')
+      p = Keynote.present(view, "keynote/nested", 'hello')
 
       p.wont_be_nil
       p.must_be_instance_of Keynote::NestedPresenter


### PR DESCRIPTION
Allow #present to accept string as presenter name in order to pass namespaces presenter more conveniently
