### PR TITLE
Ensure block is yielded even when presenter is cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+- Ensure the block passed to `Keynote.present` is executed both when creating a new presenter and when retrieving one from the cache.  
+
 ## v2.0.0 (2025-01-10)
 
 - Update the inline template API to pass source as string instead of parsing comments. [@palkan][]

--- a/lib/keynote/core.rb
+++ b/lib/keynote/core.rb
@@ -44,11 +44,12 @@ module Keynote
         presenter_name_from_object(objects[0])
       end
 
-      Cache.fetch(name, view, *objects) do
-        presenter_from_name(name).new(view, *objects).tap do |presenter|
-          yield presenter if block_given?
-        end
+      presenter = Cache.fetch(name, view, *objects) do
+        presenter_from_name(name).new(view, *objects)
       end
+
+      yield presenter if block_given?
+      presenter
     end
 
     private

--- a/spec/keynote_spec.rb
+++ b/spec/keynote_spec.rb
@@ -41,6 +41,23 @@ describe Keynote do
       end
     end
 
+    it "yields to the block even when the presenter is cached" do
+      m = double
+      expect(m).to receive(:block_yielded).twice
+
+      2.times do
+        Keynote.present(view, :normal, "hello") do |p|
+          m.block_yielded
+
+          expect(p).not_to be_nil
+          expect(p).to be_a(NormalPresenter)
+
+          expect(p.view).to eq(view)
+          expect(p.model).to eq("hello")
+        end
+      end
+    end
+
     it "integrates with Rumble" do
       p = Keynote.present(view, model)
       rx = /<div>&lt;script&gt;alert\(/


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR fixes an issue where the block passed to `Keynote.present` was only executed when a presenter was created but not when retrieved from the cache.

## What changes did you make? (overview)

- Updated `Keynote.present` logic to always yield the block, regardless of whether the presenter is created or cached.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation

