### PR TITLE
Fix call reload! in rails 8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,10 @@ end
 
 ### MiniTest
 
-Your test classes should inherit from Keynote::TestCase.
-
 ```ruby
-class UserPresenterTest < Keynote::TestCase
+class UserPresenterTest < ActiveSupport::TestCase
+  include Keynote::TestHelpers
+
   setup do
     user = User.new(first_name: "Alice", last_name: "Smith")
     @presenter = present(user)

--- a/lib/keynote/railtie.rb
+++ b/lib/keynote/railtie.rb
@@ -26,10 +26,8 @@ module Keynote
         require "keynote/testing/rspec"
       end
 
-      begin
-        ::ActionView::TestCase # rubocop:disable Lint/Void
+      if defined?(ActiveSupport::TestCase)
         require "keynote/testing/minitest"
-      rescue
       end
     end
   end

--- a/lib/keynote/testing/minitest.rb
+++ b/lib/keynote/testing/minitest.rb
@@ -1,26 +1,19 @@
 # frozen_string_literal: true
 
-# Mutually exclusive with the Keynote::TestCase defined in
-# keynote/testing/test_unit. This is kind of icky but consistent with how
-# MT::R itself replaces the Rails test case classes.
-
 require "keynote/testing/test_present_method"
 
 module Keynote
-  class TestCase < ::ActionView::TestCase
+  module TestHelper
     include TestPresentMethod
 
-    # describe SomePresenter do
-    register_spec_type(self) do |desc|
-      desc < Keynote::Presenter if desc.is_a?(Class)
+    def view
+      if defined?(@controller) && @controller
+        @controller.view_context
+      else
+        ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
+      end
     end
 
-    # describe "SomePresenter" do
-    register_spec_type(/presenter( ?test)?\z/i, self)
-
-    # Don't try to include any particular helper, since we're not testing one
-    def self.include_helper_modules!
-      include _helpers
-    end
+    alias_method :view_context, :view
   end
 end

--- a/test/test_case_test.rb
+++ b/test/test_case_test.rb
@@ -2,7 +2,9 @@
 
 require "test_helper"
 
-class Foo::BarPresenterTest < Keynote::TestCase
+class Foo::BarPresenterTest < ActiveSupport::TestCase
+  include Keynote::TestHelper
+
   setup do
     @presenter = Foo::BarPresenter.new(view, :model)
   end


### PR DESCRIPTION
### What is the purpose of this pull request?                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                            
Fix reload! crash in Rails 8.1.1 irb console.  
```
Loading development environment (Rails 8.1.1)
synchronize(dev):001> reload!
Reloading...
=> true
(dev):002> puts "Ruby on Rails!"
.ruby/3.4.8/lib/ruby/gems/3.4.0/gems/irb-1.15.3/lib/irb.rb:415:in 'full_message': undefined method '[]' for nil (NoMethodError)
        current_instances[current_instances_key] ||= new
```                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
### What changes did you make?                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
 Solution:                                                                                                                                                                                                                                                                                                                 
 - Replaced Keynote::TestCase class with Keynote::TestHelper module                                                                                                                                                                                                                                                        
 - Changed railtie loading condition from begin/rescue with ActionView::TestCase to if defined?(ActiveSupport::TestCase)                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
### Is there anything you'd like reviewers to focus on?
Breaking change: Tests need to change from:
```ruby
class MyPresenterTest < Keynote::TestCase
```                                                                                                                                                                                                                                                                                 
to: 
```ruby
class MyPresenterTest < ActiveSupport::TestCase                                                                                                                                                                                                                                                                           
    include Keynote::TestHelper      
```    

Unfortunately, I didn't have time to investigate the root cause. It's possible that the behavior of reload! changed in Rails 8.1. However, this fix resolves the issue 
    